### PR TITLE
fix: Android namespace for AGP 8+ compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'com.equalizer.flutter.equalizer_flutter'
     compileSdkVersion 31
 
     compileOptions {


### PR DESCRIPTION
Add the Android namespace property to android/build.gradle in the equalizer_flutter plugin (set to com.equalizer.flutter.equalizer_flutter) to satisfy Android Gradle Plugin 8+ requirements and resolve the "Namespace not specified" Gradle configuration error when using the plugin as a local/path dependency.